### PR TITLE
Implement i18n

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@
 /pkg/
 /spec/reports/
 /tmp/
+
+# The repo does not want this checked in
+.ruby-version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## master
 
+## 0.4.0 (TBD)
+
+- [PR [#9](https://github.com/anjlab/graphql_authorize/pull/9)] Implement I18n  ([@krider2010][])
+
 ## 0.3.0 (2018-10-09)
 
 - [PR [#7](https://github.com/DmitryTsepelev/ar_lazy_preload/pull/7)] Remove global exception handler  ([@DmitryTsepelev][])
@@ -16,3 +20,4 @@
 
 [@DmitryTsepelev]: https://github.com/DmitryTsepelev
 [@serggl]: https://github.com/serggl
+[@krider2010]: https://github.com/krider2010

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     graphql_authorize (0.3.0)
       graphql (>= 1.6)
+      i18n (~> 1.1)
 
 GEM
   remote: https://rubygems.org/
@@ -16,9 +17,20 @@ GEM
     cancancan (2.2.0)
     concurrent-ruby (1.0.5)
     diff-lcs (1.3)
+    erubi (1.7.1)
     graphql (1.8.10)
+    highline (2.0.0)
     i18n (1.1.0)
       concurrent-ruby (~> 1.0)
+    i18n-tasks (0.9.25)
+      activesupport (>= 4.0.2)
+      ast (>= 2.1.0)
+      erubi
+      highline (>= 2.0.0)
+      i18n
+      parser (>= 2.2.3.0)
+      rainbow (>= 2.2.2, < 4.0)
+      terminal-table (>= 1.5.1)
     jaro_winkler (1.5.1)
     minitest (5.11.3)
     parallel (1.12.1)
@@ -51,6 +63,8 @@ GEM
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.10.0)
+    terminal-table (1.8.0)
+      unicode-display_width (~> 1.1, >= 1.1.1)
     thread_safe (0.3.6)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
@@ -64,10 +78,11 @@ DEPENDENCIES
   bundler (~> 1.16)
   cancancan (~> 2.0)
   graphql_authorize!
+  i18n-tasks (~> 0.9.25)
   pundit
   rake (~> 10.0)
   rspec
   rubocop
 
 BUNDLED WITH
-   1.16.5
+   1.16.6

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -1,0 +1,38 @@
+# i18n-tasks finds and manages missing and unused translations: https://github.com/glebm/i18n-tasks
+
+# The "main" locale.
+base_locale: en
+
+# Read and write translations.
+data:
+  # Locale files or `File.find` patterns where translations are read from:
+  read:
+    ## Default:
+    # - config/locales/%{locale}.yml
+
+  # Locale files to write new keys to, based on a list of key pattern => file rules. Matched from top to bottom:
+  # `i18n-tasks normalize -p` will force move the keys according to these rules
+  write:
+    ## Catch-all default:
+    # - config/locales/%{locale}.yml
+
+  # External locale data (e.g. gems).
+  # This data is not considered unused and is never written to.
+  external:
+
+  yaml:
+    write:
+      # do not wrap lines at 80 characters
+      line_width: -1
+
+# Find translate calls
+search:
+  ## Paths or `File.find` patterns to search in:
+  paths:
+   - lib/
+
+  ## Files or `File.fnmatch` patterns to exclude from search. Some files are always excluded regardless of this setting:
+  exclude:
+    - app/assets/images
+    - app/assets/fonts
+    - app/assets/videos

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,0 +1,8 @@
+---
+en:
+  graphql_authorize:
+    auth:
+      canrespond: an object returned by \#auth_adapter_source call does not respond to \#can?
+      arrayargs: \#authorize arguments should be passed as array, e.g. `authorize [:read, Post]`
+    graphql:
+      accessdenied: Access to the field '%{name}' is denied!

--- a/graphql_authorize.gemspec
+++ b/graphql_authorize.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.3"
 
   spec.add_dependency "graphql", ">= 1.6"
+  spec.add_dependency "i18n", "~> 1.1"
 
   spec.add_development_dependency "bundler", "~> 1.16"
   spec.add_development_dependency "rake", "~> 10.0"
@@ -34,4 +35,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "cancancan", "~> 2.0"
   spec.add_development_dependency "pundit"
   spec.add_development_dependency "activesupport"
+  spec.add_development_dependency "i18n-tasks", "~> 0.9.25"
 end

--- a/lib/graphql_authorize.rb
+++ b/lib/graphql_authorize.rb
@@ -27,6 +27,9 @@ module GraphqlAuthorize
     end
   end
 
+  # Default, if not specified, is :en
+  I18n.load_path << Dir[File.expand_path("config/locales") + "/*.yml"]
+
   GraphQL::Field.include(GraphqlAuthorize::Field)
 
   GraphQL::Schema::Field.include(GraphqlAuthorize::SchemaField) if supports_class_syntax?

--- a/lib/graphql_authorize/auth_adapters/can_can_can.rb
+++ b/lib/graphql_authorize/auth_adapters/can_can_can.rb
@@ -5,13 +5,11 @@ module GraphqlAuthorize
     class CanCanCan < Base
       def authorize
         unless field_definition.authorize.is_a?(Array)
-          raise ArgumentError,
-                "#authorize arguments should be passed as array, e.g. `authorize [:read, Post]`"
+          raise ArgumentError, I18n.t("graphql_authorize.auth.arrayargs")
         end
 
         unless source.respond_to?(:can?)
-          raise ArgumentError,
-                "an object returned by #auth_adapter_source call does not respond to #can?"
+          raise ArgumentError, I18n.t("graphql_authorize.auth.canrespond")
         end
 
         source.can?(*field_definition.authorize)

--- a/lib/graphql_authorize/ext/field_resolve_step.rb
+++ b/lib/graphql_authorize/ext/field_resolve_step.rb
@@ -7,7 +7,9 @@ module GraphqlAuthorize
       if authorized?(field_definition, parent_object, field_args, context)
         super
       else
-        GraphQL::ExecutionError.new("Access to the field '#{field_definition.name}' is denied!")
+        GraphQL::ExecutionError.new(
+          I18n.t("graphql_authorize.graphql.accessdenied", name: field_definition.name)
+        )
       end
     end
     # rubocop:enable Metrics/ParameterLists

--- a/spec/i18n_spec.rb
+++ b/spec/i18n_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require "i18n/tasks"
+
+RSpec.describe "I18n" do
+  let(:i18n) { I18n::Tasks::BaseTask.new }
+  let(:missing_keys) { i18n.missing_keys }
+  let(:unused_keys) { i18n.unused_keys }
+
+  it "does not have missing keys" do
+    expect(missing_keys).to be_empty,
+                            "Missing #{missing_keys.leaves.count} i18n keys, " \
+                            "run `i18n-tasks missing' to show them"
+  end
+
+  it "does not have unused keys" do
+    expect(unused_keys).to be_empty,
+                           "#{unused_keys.leaves.count} unused i18n keys, " \
+                           "run `i18n-tasks unused' to show them"
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "graphql_authorize"
+require "i18n"
 
 RSpec.configure do |config|
   config.order = :random


### PR DESCRIPTION
This is a first pass (so far) to include i18n and extract those strings to an English translation file (the default language). It addresses https://github.com/anjlab/graphql_authorize/issues/7.

The use of `i18n` rather than `gettext` or other similar things was chosen because:

* it's consistent with anyone wanting to use this gem in a rails app
* It's easier to ship the translatable strings of a gem as YAML files

I've also included `i18n-tasks` as a development dependency so that it is easier to handle missing translations and unused keys.

I'm more than happy to have a chat about anything I've missed or misunderstood or ... 😄 